### PR TITLE
macOS 빌드 오류 수정 및 .gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+Release/

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,13 @@
 function jumpto
 {
     label=$1
-    cmd=$(sed -n "/$label:/{:a;n;p;ba};" $0 | grep -v ':$')
+    cmd=$(sed -n "/$label:/{
+        :a
+        n
+        p
+        ba
+        };" $0 | grep -v ':$'
+    )
     eval "$cmd"
     exit
 }


### PR DESCRIPTION
1. macOS(OSX)의 sed가 세미콜론(;)을 제대로 해석하지 못하는 문제가 있고, 해결을 위해서는 ; 대신 개행문자를 사용해야 합니다. Linux는 둘 다 지원하므로 이 수정으로 인한 문제는 없습니다.
2. .gitignore 파일을 추가하고 개발 과정에서 임시로 생성되는 파일들을 git이 무시하도록 설정했습니다.
