### PR TITLE
update.cfg 파일 존재 구문 확인

### DIFF
--- a/Engine/k2.py
+++ b/Engine/k2.py
@@ -440,6 +440,7 @@ def update_kicomav(path):
         # 업데이트해야 할 파일 목록을 구한다.
         down_list = get_download_list(url, path)
         is_k2_exe_update = 'k2.exe' in down_list
+        update_file = os.path.join(path, 'update.cfg')
 
         while len(down_list) != 0:
             filename = down_list.pop(0)
@@ -451,13 +452,16 @@ def update_kicomav(path):
         if os.name == 'nt' and is_k2_exe_update:
             k2temp_path = download_file_k2(url, 'k2.exe', path, gz=True, fnhook=hook)
 
+        if not os.path.isfile(update_file):
+            raise FileNotFoundException
+
         # 업데이트 완료 메시지 출력
         cprint('\n[', FOREGROUND_GREY)
         cprint('Update complete', FOREGROUND_GREEN)
         cprint(']\n', FOREGROUND_GREY)
 
         # 업데이트 설정 파일 삭제
-        os.remove(os.path.join(path, 'update.cfg'))
+        os.remove(update_file)
 
         # k2.exe의 경우 최종 업데이트 프로그램 실행
         if os.name == 'nt' and is_k2_exe_update:
@@ -468,7 +472,7 @@ def update_kicomav(path):
         cprint(']\n', FOREGROUND_GREY)
     except:
         cprint('\n[', FOREGROUND_GREY)
-        cprint('Update faild', FOREGROUND_RED | FOREGROUND_INTENSITY)
+        cprint('Update failed', FOREGROUND_RED | FOREGROUND_INTENSITY)
         cprint(']\n', FOREGROUND_GREY)
 
 


### PR DESCRIPTION
코드에 업데이트 파일이 존재하는지 확인하는 구문 없이 바로 삭제 명령을 수행하는 부분을 확인하였습니다.

이러한 루틴으로 인해 #10 이슈와 같이 인터넷 연결이 되지 않는 경우 "Update complete" 구문까지는 정상적으로 수행되지만 update.cfg 파일을 삭제할 때 존재하지 않는 파일을 삭제하고자 시도하기 때문에 에러가 발생하게 되는 문제가 있습니다.

이러한 문제를 해결하기 위해 update.cfg 파일이 존재하는지 확인한 뒤, 존재하지 않는 경우에는 FileNotFoundException을 발생시켜 예외처리 할 수 있도록 작업하였습니다.