### PR TITLE
Add Requirements 'six'

### DIFF
--- a/Engine/k2.py
+++ b/Engine/k2.py
@@ -974,7 +974,7 @@ def main():
     options, args = parser_options()
     g_options = options  # 글로벌 options 셋팅
 
-    if os.name == 'nt' and not isinstance(options, types.StringType):
+    if os.name == 'nt' and not isinstance(options, str):
         if options.opt_nocolor:
             NOCOLOR = True
 

--- a/Engine/k2.py
+++ b/Engine/k2.py
@@ -26,7 +26,7 @@ import os
 import sys
 import types
 import hashlib
-import urllib
+import urllib.request
 import time
 import struct
 import datetime
@@ -554,7 +554,7 @@ def get_download_list(url, path):
         download_file(url, 'update.cfg', pwd)
 
         buf = open(os.path.join(pwd, 'update.cfg'), 'r').read()
-        p_lists = re.compile(rb'([A-Fa-f0-9]{40}) (.+)')
+        p_lists = re.compile(r'([A-Fa-f0-9]{40}) (.+)')
         lines = p_lists.findall(buf)
 
         for line in lines:


### PR DESCRIPTION
[Fix] No module named 'six'
Six is Python 2 and 3 Compatibility Library

OS : Windows 10.0.19044.2006
python : 3.9.6